### PR TITLE
Add compilation script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ build/
 
 ### Mac OS ###
 .DS_Store
+
+# Build output
+out/

--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ Alternatively, you can open the project directly in IntelliJ IDEA from VCS:
 ## ⚙️ Usage
 Navigate to the project directory and open the project using your favorite IDE (such as IntelliJ IDEA or Eclipse). You can run the training modules by executing the provided Java files. Each module is designed to cover specific topics in Java, with detailed explanations and example code.
 
+For a quick compilation of all examples, run the provided `compile.sh` script:
+```bash
+./compile.sh
+```
+This will compile every Java file into the `out` directory.
+
 ## ✨ Features
 - 42-day Java training program  
 - Practical exercises and real-world examples  

--- a/compile.sh
+++ b/compile.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+OUT_DIR="out"
+rm -rf "$OUT_DIR"
+mkdir -p "$OUT_DIR"
+find src -name '*.java' > sources.txt
+javac -d "$OUT_DIR" @sources.txt
+rm sources.txt
+echo "Compilation successful. Classes are in $OUT_DIR" 


### PR DESCRIPTION
## Summary
- add `compile.sh` to build all examples
- ignore the new `out/` folder in `.gitignore`
- document the compile script in the README